### PR TITLE
Update generate_wasm_pkg.sh

### DIFF
--- a/generate_wasm_pkg.sh
+++ b/generate_wasm_pkg.sh
@@ -1,6 +1,6 @@
 git submodule update --init --recursive --remote
 cd Warp/extensions/warp-ipfs
-wasm-pack build --target web
+RUSTFLAGS='-C target-feature=+atomics' wasm-pack build --target web
 
 cd ../../..
 


### PR DESCRIPTION
While debugging, I've observed some odd behaviour with several operations in wasm causing some functions to present with UB (undefined behaviours). While still not considered stable, adding the `atomics` flag seem to correct some of these behaviours, although with the flag enabled, we also dont know what bugs may be presented. 