### PR TITLE
add ts typing to missing ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
  "gloo-render",
  "gloo-storage",
  "gloo-timers",
- "gloo-utils",
+ "gloo-utils 0.1.7",
  "gloo-worker",
 ]
 
@@ -1726,7 +1726,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b7ce3c05debe147233596904981848862b068862e9ec3e34be446077190d3f"
 dependencies = [
- "gloo-utils",
+ "gloo-utils 0.1.7",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -1772,7 +1772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85725d90bf0ed47063b3930ef28e863658a7905989e9929a8708aab74a1d5e7f"
 dependencies = [
  "gloo-events",
- "gloo-utils",
+ "gloo-utils 0.1.7",
  "serde",
  "serde-wasm-bindgen 0.5.0",
  "serde_urlencoded",
@@ -1790,7 +1790,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
- "gloo-utils",
+ "gloo-utils 0.1.7",
  "js-sys",
  "pin-project",
  "serde",
@@ -1817,7 +1817,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6ab60bf5dbfd6f0ed1f7843da31b41010515c745735c970e821945ca91e480"
 dependencies = [
- "gloo-utils",
+ "gloo-utils 0.1.7",
  "js-sys",
  "serde",
  "serde_json",
@@ -1852,6 +1852,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "gloo-worker"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,7 +1873,7 @@ dependencies = [
  "anymap2",
  "bincode",
  "gloo-console",
- "gloo-utils",
+ "gloo-utils 0.1.7",
  "js-sys",
  "serde",
  "slab",
@@ -4845,6 +4858,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "serde_ipld_dagcbor"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5611,6 +5635,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tsify-next"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4a645dca4ee0800f5ab60ce166deba2db6a0315de795a2691e138a3d55d756"
+dependencies = [
+ "gloo-utils 0.2.0",
+ "serde",
+ "serde_json",
+ "tsify-next-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-next-macros"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5c06f8a51d759bb58129e30b2631739e7e1e4579fad1f30ac09a6c88e488a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5830,6 +5879,7 @@ dependencies = [
  "tiny_file_server",
  "tracing-subscriber",
  "tracing-wasm",
+ "tsify-next",
  "uuid",
  "warp",
  "warp-ipfs 0.1.0 (git+https://github.com/Satellite-im/Warp.git?rev=eddf12f2f00b88d19edd1bdd98fbd70a3151cd5a)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ wasm-streams = "0.4"
 send_wrapper = "0.6.0"
 web-sys = "0.3"
 js-sys = "0.3"
+tsify-next = "0.5.4"
 
 # examples
 tiny_file_server = "0.1.5"

--- a/examples/from-js/ipfs-raygun.html
+++ b/examples/from-js/ipfs-raygun.html
@@ -74,6 +74,10 @@
       let msg_id = await warp_a.raygun.send(conversation_a.id(), msg)
       console.log(`identity: ${identity_a.username()} \nmsg_id: ${msg_id} \nmsg: ${msg} `)
 
+      let perm = new wasm.GroupPermissions()
+      console.log("pre ", perm.get_permissions(identity_b.did_key()), [wasm.GroupPermission.AddParticipants])
+      perm.set_permissions(identity_b.did_key(), [wasm.GroupPermission.AddParticipants])
+      console.log("post ", perm.get_permissions(identity_b.did_key()))
     });
   </script>
   <body>

--- a/src/warp/constellation.rs
+++ b/src/warp/constellation.rs
@@ -314,9 +314,7 @@ pub struct File {
 
 impl File {
     pub fn from_file(inner: constellation::file::File) -> File {
-        File {
-            inner,
-        }
+        File { inner }
     }
 }
 

--- a/src/warp/constellation.rs
+++ b/src/warp/constellation.rs
@@ -250,8 +250,7 @@ impl Directory {
     }
     pub fn set_thumbnail_format(&self, format: FileType) {
         let format: warp::constellation::file::FileType = format.into();
-        self.inner
-            .set_thumbnail_format(format.into())
+        self.inner.set_thumbnail_format(format.into())
     }
     pub fn thumbnail_format(&self) -> FileType {
         let format: warp::constellation::file::FileType = self.inner.thumbnail_format().into();
@@ -336,8 +335,7 @@ impl File {
     }
     pub fn set_thumbnail_format(&self, format: FileType) {
         let format: warp::constellation::file::FileType = format.into();
-        self.inner
-            .set_thumbnail_format(format.into())
+        self.inner.set_thumbnail_format(format.into())
     }
     pub fn thumbnail_format(&self) -> FileType {
         let format: warp::constellation::file::FileType = self.inner.thumbnail_format().into();
@@ -386,8 +384,7 @@ impl File {
         self.inner.set_hash(hash.into())
     }
     pub fn set_file_type(&self, file_type: FileType) {
-        self.inner
-            .set_file_type(file_type.into())
+        self.inner.set_file_type(file_type.into())
     }
     pub fn file_type(&self) -> FileType {
         self.inner.file_type().into()
@@ -493,8 +490,7 @@ impl Item {
     }
     pub fn set_thumbnail_format(&self, format: FileType) {
         let format: warp::constellation::file::FileType = format.into();
-        self.inner
-            .set_thumbnail_format(format.into())
+        self.inner.set_thumbnail_format(format.into())
     }
     pub fn set_size(&self, size: usize) -> Result<(), JsError> {
         self.inner.set_size(size).map_err(|e| e.into())
@@ -638,7 +634,9 @@ impl From<&constellation::file::FileType> for FileType {
     fn from(value: &constellation::file::FileType) -> Self {
         match value {
             constellation::file::FileType::Generic => FileType::Generic,
-            constellation::file::FileType::Mime(media_type_buf) => FileType::Mime(media_type_buf.to_string()),
+            constellation::file::FileType::Mime(media_type_buf) => {
+                FileType::Mime(media_type_buf.to_string())
+            }
         }
     }
 }
@@ -647,7 +645,9 @@ impl From<constellation::file::FileType> for FileType {
     fn from(value: constellation::file::FileType) -> Self {
         match value {
             constellation::file::FileType::Generic => FileType::Generic,
-            constellation::file::FileType::Mime(media_type_buf) => FileType::Mime(media_type_buf.to_string()),
+            constellation::file::FileType::Mime(media_type_buf) => {
+                FileType::Mime(media_type_buf.to_string())
+            }
         }
     }
 }
@@ -656,7 +656,9 @@ impl Into<constellation::file::FileType> for FileType {
     fn into(self) -> constellation::file::FileType {
         match self {
             FileType::Generic => constellation::file::FileType::Generic,
-            FileType::Mime(media_type_buf) => constellation::file::FileType::Mime(media_type_buf.parse().unwrap()),
+            FileType::Mime(media_type_buf) => {
+                constellation::file::FileType::Mime(media_type_buf.parse().unwrap())
+            }
         }
     }
 }

--- a/src/warp/constellation.rs
+++ b/src/warp/constellation.rs
@@ -311,6 +311,15 @@ impl Directory {
 pub struct File {
     inner: constellation::file::File,
 }
+
+impl File {
+    pub fn from_file(inner: constellation::file::File) -> File {
+        File {
+            inner,
+        }
+    }
+}
+
 #[wasm_bindgen]
 impl File {
     pub fn new(name: &str) -> File {

--- a/src/warp/multipass.rs
+++ b/src/warp/multipass.rs
@@ -150,7 +150,7 @@ impl MultiPassBox {
             .list_incoming_request()
             .await
             .map_err(|e| e.into())
-            .map(|ok| ok.into_iter().map(|r|r.into()).collect())
+            .map(|ok| ok.into_iter().map(|r| r.into()).collect())
     }
 
     /// Check to determine if a request been sent to the DID
@@ -167,7 +167,7 @@ impl MultiPassBox {
             .list_outgoing_request()
             .await
             .map_err(|e| e.into())
-            .map(|ok| ok.into_iter().map(|r|r.into()).collect())
+            .map(|ok| ok.into_iter().map(|r| r.into()).collect())
     }
 
     /// Remove friend from contacts
@@ -322,8 +322,12 @@ impl Into<identity::IdentityUpdate> for IdentityUpdate {
             IdentityUpdate::ClearBanner => identity::IdentityUpdate::ClearBanner,
             IdentityUpdate::StatusMessage(value) => identity::IdentityUpdate::StatusMessage(value),
             IdentityUpdate::ClearStatusMessage => identity::IdentityUpdate::ClearStatusMessage,
-            IdentityUpdate::AddMetadataKey{key, value } => identity::IdentityUpdate::AddMetadataKey{ key, value },
-            IdentityUpdate::RemoveMetadataKey(key) => identity::IdentityUpdate::RemoveMetadataKey { key },
+            IdentityUpdate::AddMetadataKey { key, value } => {
+                identity::IdentityUpdate::AddMetadataKey { key, value }
+            }
+            IdentityUpdate::RemoveMetadataKey(key) => {
+                identity::IdentityUpdate::RemoveMetadataKey { key }
+            }
         }
     }
 }
@@ -352,13 +356,12 @@ impl Into<identity::Identifier> for Identifier {
 
 #[wasm_bindgen]
 pub struct FriendRequest {
-     identity: String,
-     date: js_sys::Date,
+    identity: String,
+    date: js_sys::Date,
 }
 
 #[wasm_bindgen]
 impl FriendRequest {
-
     #[wasm_bindgen(getter)]
     pub fn identity(&self) -> String {
         self.identity.clone()


### PR DESCRIPTION
This PR adds typescript typings to all current functions that return `any` making it much clearer on the js side on what it returns.
Due to a wasm limitation currently this is not possible with `AsyncIterator` so those still return `Promise<any>`.
This contains some breaking changes.