### PR TITLE
feat: Auto convert macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,7 +3454,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4907,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
@@ -4968,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6077,7 +6077,7 @@ dependencies = [
  "macro_utils",
  "send_wrapper 0.6.0",
  "serde",
- "serde-wasm-bindgen 0.4.5",
+ "serde-wasm-bindgen 0.6.5",
  "tiny_file_server",
  "tracing-subscriber",
  "tracing-wasm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3449,6 +3449,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_utils"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6065,6 +6074,7 @@ dependencies = [
  "futures",
  "indexmap 2.7.0",
  "js-sys",
+ "macro_utils",
  "send_wrapper 0.6.0",
  "serde",
  "serde-wasm-bindgen 0.4.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ send_wrapper = "0.6.0"
 web-sys = "0.3"
 js-sys = "0.3"
 tsify-next = "0.5.4"
+macro_utils = { path = "./macro-utils" }
 
 # examples
 tiny_file_server = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ bytes = { version = "1", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
-indexmap = { version = "2.2.6", features = ["serde"] }
+indexmap = { version = "2.7.0", features = ["serde"] }
 
 # warp
 warp-ipfs = { git = "https://github.com/Satellite-im/Warp.git", rev = "fdb96da58174b41548992b3dcaba40a01b10ecf9"}
@@ -19,11 +19,11 @@ warp = { git = "https://github.com/Satellite-im/Warp.git", rev = "fdb96da58174b4
 
 # wasm
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-wasm = "0.2.0"
+tracing-wasm = "0.2.1"
 console_error_panic_hook = "0.1.7"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-serde-wasm-bindgen = "0.4"
+serde-wasm-bindgen = "0.6"
 wasm-streams = "0.4"
 send_wrapper = "0.6.0"
 web-sys = "0.3"

--- a/macro-utils/Cargo.toml
+++ b/macro-utils/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "macro_utils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+syn = { version = "2.0.87", features = ["derive", "full"] }
+quote = "1.0.37"
+proc-macro2 = "1.0.89"
+
+[lib]
+proc-macro = true

--- a/macro-utils/src/lib.rs
+++ b/macro-utils/src/lib.rs
@@ -5,10 +5,15 @@ use proc_macro::TokenStream;
 mod wasm_convert;
 
 /// Easy type conversion between enums and structs of similar structure
+/// 
 /// Also allows specifying a function for conversion for types not implementing From already
+/// 
 /// Fields can accept an attribute with name "from" or "into" representing a conversion function.
+/// 
 /// This value can either be a path to a function or some rust code. 
+/// 
 /// The path need to accept a single value of the current type and output the target type
+/// 
 /// Unnamed enum fields are referenced as f_0, f_1...
 /// E.g. `"{f_0}.converter_function()"`
 /// ```

--- a/macro-utils/src/lib.rs
+++ b/macro-utils/src/lib.rs
@@ -23,7 +23,6 @@ mod wasm_convert;
 ///     SomeValue2
 /// }
 /// 
-/// 
 /// assert_eq!(A::SomeValue1, B::SomeValue1.into());
 /// 
 /// pub struct S1 {
@@ -41,7 +40,10 @@ mod wasm_convert;
 /// #[derive(FromTo)]
 /// #[from_to(A)]
 /// pub struct S3 {
+///     // Pass in a custom conversion function. If not provided will use a From implementation
 ///     #[from_to(from = "converter_function", to = "converter_function")]
+///     // Referencing the struct itself is also possible
+///     #[from_to(from = "{value}.x.converter_function()", to = "{value}.x.converter_function()")]
 ///     x: String,
 ///     #[from_to(from = "converter_function", to = "converter_function")]
 ///     y: String

--- a/macro-utils/src/lib.rs
+++ b/macro-utils/src/lib.rs
@@ -1,0 +1,55 @@
+extern crate proc_macro2;
+
+use proc_macro::TokenStream;
+
+mod wasm_convert;
+
+/// Easy type conversion between enums and structs of similar structure
+/// Also allows specifying a function for conversion for types not implementing From already
+/// 
+/// ```
+/// use macro_utils::FromTo;
+/// 
+/// #[derive(Debug)]
+/// pub enum A {
+///     SomeValue1,
+///     SomeValue2
+/// }
+/// 
+/// #[derive(FromTo, PartialEq, Debug)]
+/// #[from_to(A)]
+/// pub enum B {
+///     SomeValue1,
+///     SomeValue2
+/// }
+/// 
+/// 
+/// assert_eq!(A::SomeValue1, B::SomeValue1.into());
+/// 
+/// pub struct S1 {
+///     x: i64,
+///     y: i128
+/// }
+/// 
+/// #[derive(FromTo)]
+/// #[from_to(A)]
+/// pub struct S2 {
+///     x: i64,
+///     y: i128
+/// }
+/// 
+/// #[derive(FromTo)]
+/// #[from_to(A)]
+/// pub struct S3 {
+///     #[from_to(from = "converter_function", to = "converter_function")]
+///     x: String,
+///     #[from_to(from = "converter_function", to = "converter_function")]
+///     y: String
+/// }
+/// ```
+#[proc_macro_derive(FromTo, attributes(from_to))]
+pub fn from_to(input: TokenStream) -> TokenStream {
+    wasm_convert::expand(input)
+        .unwrap_or_else(|e| e.into_compile_error().into())
+        .into()
+}

--- a/macro-utils/src/lib.rs
+++ b/macro-utils/src/lib.rs
@@ -6,7 +6,11 @@ mod wasm_convert;
 
 /// Easy type conversion between enums and structs of similar structure
 /// Also allows specifying a function for conversion for types not implementing From already
-/// 
+/// Fields can accept an attribute with name "from" or "into" representing a conversion function.
+/// This value can either be a path to a function or some rust code. 
+/// The path need to accept a single value of the current type and output the target type
+/// Unnamed enum fields are referenced as f_0, f_1...
+/// E.g. `"{f_0}.converter_function()"`
 /// ```
 /// use macro_utils::FromTo;
 /// 
@@ -41,11 +45,11 @@ mod wasm_convert;
 /// #[from_to(A)]
 /// pub struct S3 {
 ///     // Pass in a custom conversion function. If not provided will use a From implementation
-///     #[from_to(from = "converter_function", to = "converter_function")]
+///     #[from_to(from = "converter_function_from", to = "converter_function_to")]
 ///     // Referencing the struct itself is also possible
 ///     #[from_to(from = "{value}.x.converter_function()", to = "{value}.x.converter_function()")]
 ///     x: String,
-///     #[from_to(from = "converter_function", to = "converter_function")]
+///     #[from_to(from = "converter_function_from", to = "converter_function_to")]
 ///     y: String
 /// }
 /// ```

--- a/src/warp/constellation.rs
+++ b/src/warp/constellation.rs
@@ -91,7 +91,6 @@ impl ConstellationBox {
 
     /// Returns a progression stream
     /// The result of the stream is of type {@link Progression}
-    /// See https://github.com/Satellite-im/Warp/blob/main/warp/src/raygun/mod.rs#L306
     pub async fn put_stream(
         &mut self,
         name: &str,
@@ -538,8 +537,9 @@ impl From<Item> for constellation::item::Item {
     }
 }
 
-#[derive(serde::Serialize, FromTo)]
+#[derive(Tsify, Serialize, FromTo)]
 #[from_to(constellation::Progression, only = "from")]
+#[serde(tag = "kind", content = "values", rename_all="snake_case")]
 pub enum Progression {
     CurrentProgress {
         /// name of the file

--- a/src/warp/multipass.rs
+++ b/src/warp/multipass.rs
@@ -370,7 +370,7 @@ pub enum Identifier {
 
 fn to_did_vec(dids: Vec<String>) -> Vec<DID> {
     dids.into_iter()
-        .map(|did| DID::from_str(&did).unwrap())
+        .filter_map(|did| DID::from_str(&did).ok())
         .collect()
 }
 

--- a/src/warp/multipass.rs
+++ b/src/warp/multipass.rs
@@ -388,6 +388,7 @@ pub struct FriendRequest {
 
 #[derive(Tsify, Serialize, Deserialize, FromTo)]
 #[from_to(multipass::MultiPassEventKind, only = "from")]
+#[serde(tag = "kind", content = "values", rename_all="snake_case")]
 pub enum MultiPassEventKind {
     FriendRequestReceived {
         from: String,

--- a/src/warp/multipass.rs
+++ b/src/warp/multipass.rs
@@ -391,13 +391,13 @@ pub struct FriendRequest {
 pub enum MultiPassEventKind {
     FriendRequestReceived {
         from: String,
-        #[tsify(type = "Date")]
-        date: String,
+        #[serde(with = "serde_wasm_bindgen::preserve")]
+        date: js_sys::Date,
     },
     FriendRequestSent {
         to: String,
-        #[tsify(type = "Date")]
-        date: String,
+        #[serde(with = "serde_wasm_bindgen::preserve")]
+        date: js_sys::Date,
     },
     IncomingFriendRequestRejected {
         did: String,

--- a/src/warp/raygun.rs
+++ b/src/warp/raygun.rs
@@ -2098,7 +2098,7 @@ impl From<raygun::LocationKind> for LocationKind {
         match value {
             raygun::LocationKind::Constellation { path } => LocationKind::Constellation { path },
             raygun::LocationKind::Stream { name } => LocationKind::Stream { name },
-            raygun::LocationKind::Disk { .. } => todo!("Disk Location not supported on wasm"),
+            raygun::LocationKind::Disk { .. } => unimplemented!("Disk Location not supported on wasm"),
         }
     }
 }

--- a/src/warp/raygun.rs
+++ b/src/warp/raygun.rs
@@ -2,6 +2,7 @@ use crate::warp::stream::{AsyncIterator, InnerStream};
 use futures::StreamExt;
 use indexmap::IndexSet;
 use js_sys::{Array, Promise};
+use macro_utils::FromTo;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tsify_next::Tsify;
@@ -519,8 +520,7 @@ impl RayGunBox {
 #[wasm_bindgen]
 impl RayGunBox {
     /// Subscribe to an stream of events from the conversation
-    /// Async results are of type MessageEventKind
-    /// See https://github.com/Satellite-im/Warp/blob/main/warp/src/raygun/mod.rs#L47
+    /// Async results are of type {@link MessageEventKind}
     pub async fn get_conversation_stream(
         &mut self,
         conversation_id: String,
@@ -530,24 +530,23 @@ impl RayGunBox {
             .await
             .map_err(|e| e.into())
             .map(|ok| {
-                AsyncIterator::new(Box::pin(
-                    ok.map(|s| serde_wasm_bindgen::to_value(&s).unwrap()),
-                ))
+                AsyncIterator::new(Box::pin(ok.map(|s| {
+                    serde_wasm_bindgen::to_value(&Into::<MessageEventKind>::into(s)).unwrap()
+                })))
             })
     }
 
     /// Subscribe to an stream of events
-    /// Async results are of type RayGunEventKind
-    /// See https://github.com/Satellite-im/Warp/blob/main/warp/src/raygun/mod.rs#L33
+    /// Async results are of type {@link RayGunEventKind}
     pub async fn raygun_subscribe(&mut self) -> Result<AsyncIterator, JsError> {
         self.inner
             .raygun_subscribe()
             .await
             .map_err(|e| e.into())
             .map(|ok| {
-                AsyncIterator::new(Box::pin(
-                    ok.map(|s| serde_wasm_bindgen::to_value(&s).unwrap()),
-                ))
+                AsyncIterator::new(Box::pin(ok.map(|s| {
+                    serde_wasm_bindgen::to_value(&Into::<RayGunEventKind>::into(s)).unwrap()
+                })))
             })
     }
 }
@@ -555,8 +554,8 @@ impl RayGunBox {
 /// impl RayGunCommunity trait
 #[wasm_bindgen]
 impl RayGunBox {
-    /// Async results are of type MessageEventKind
-    /// See https://github.com/Satellite-im/Warp/blob/main/warp/src/raygun/mod.rs#L47
+    /// Subscribe to an stream of community events for the given community
+    /// Async results are of type {@link MessageEventKind}
     pub async fn get_community_stream(
         &mut self,
         community_id: String,
@@ -567,7 +566,7 @@ impl RayGunBox {
             .map_err(|e| e.into())
             .map(|ok| {
                 AsyncIterator::new(Box::pin(
-                    ok.map(|s| serde_wasm_bindgen::to_value(&s).unwrap()),
+                    ok.map(|s| serde_wasm_bindgen::to_value(&Into::<MessageEventKind>::into(s)).unwrap()),
                 ))
             })
     }
@@ -1300,6 +1299,7 @@ impl RayGunBox {
             })
     }
     /// Stream a file that been attached to a message
+    /// Results are byte chunks for the file
     /// Note: Must use the filename associated when downloading
     pub async fn download_stream_from_community_channel_message(
         &self,
@@ -1501,6 +1501,307 @@ impl Messages {
         }
     }
 }
+
+#[derive(Tsify, Serialize, Deserialize, FromTo)]
+#[from_to(warp::raygun::RayGunEventKind, only = "from")]
+pub enum RayGunEventKind {
+    ConversationCreated {
+        conversation_id: String,
+    },
+    ConversationArchived {
+        conversation_id: String,
+    },
+    ConversationUnarchived {
+        conversation_id: String,
+    },
+    ConversationDeleted {
+        conversation_id: String,
+    },
+    CommunityCreated {
+        community_id: String,
+    },
+    CommunityInvited {
+        community_id: String,
+        invite_id: String,
+    },
+    CommunityDeleted {
+        community_id: String,
+    },
+}
+
+#[derive(Tsify, Serialize, Deserialize, FromTo)]
+#[from_to(warp::raygun::MessageEventKind, only = "from")]
+pub enum MessageEventKind {
+    MessageSent {
+        conversation_id: String,
+        message_id: String,
+    },
+    MessageReceived {
+        conversation_id: String,
+        message_id: String,
+    },
+    MessageEdited {
+        conversation_id: String,
+        message_id: String,
+    },
+    MessageDeleted {
+        conversation_id: String,
+        message_id: String,
+    },
+    MessagePinned {
+        conversation_id: String,
+        message_id: String,
+    },
+    MessageUnpinned {
+        conversation_id: String,
+        message_id: String,
+    },
+    MessageReactionAdded {
+        conversation_id: String,
+        message_id: String,
+        did_key: String,
+        reaction: String,
+    },
+    MessageReactionRemoved {
+        conversation_id: String,
+        message_id: String,
+        did_key: String,
+        reaction: String,
+    },
+    ConversationNameUpdated {
+        conversation_id: String,
+        name: String,
+    },
+    ConversationUpdatedIcon {
+        conversation_id: String,
+    },
+    ConversationUpdatedBanner {
+        conversation_id: String,
+    },
+    ConversationDescriptionChanged {
+        conversation_id: String,
+        description: Option<String>,
+    },
+    RecipientAdded {
+        conversation_id: String,
+        recipient: String,
+    },
+    RecipientRemoved {
+        conversation_id: String,
+        recipient: String,
+    },
+    EventReceived {
+        conversation_id: String,
+        did_key: String,
+        event: MessageEvent,
+    },
+    EventCancelled {
+        conversation_id: String,
+        did_key: String,
+        event: MessageEvent,
+    },
+    ConversationPermissionsUpdated {
+        conversation_id: String,
+        #[from_to(into = "map_permission")]
+        added: Vec<GroupPermissionEntry>,
+        #[from_to(into = "map_permission")]
+        removed: Vec<GroupPermissionEntry>,
+    },
+    CommunityEventReceived {
+        community_id: String,
+        community_channel_id: String,
+        did_key: String,
+        event: MessageEvent,
+    },
+    CommunityEventCancelled {
+        community_id: String,
+        community_channel_id: String,
+        did_key: String,
+        event: MessageEvent,
+    },
+    LeftCommunity {
+        community_id: String,
+    },
+    CreatedCommunityInvite {
+        community_id: String,
+        invite: CommunityInvite,
+    },
+    DeletedCommunityInvite {
+        community_id: String,
+        invite_id: String,
+    },
+    AcceptedCommunityInvite {
+        community_id: String,
+        invite_id: String,
+        user: String,
+    },
+    EditedCommunityInvite {
+        community_id: String,
+        invite_id: String,
+    },
+    CreatedCommunityRole {
+        community_id: String,
+        role: CommunityRole,
+    },
+    DeletedCommunityRole {
+        community_id: String,
+        role_id: String,
+    },
+    EditedCommunityRole {
+        community_id: String,
+        role_id: String,
+    },
+    GrantedCommunityRole {
+        community_id: String,
+        role_id: String,
+        user: String,
+    },
+    RevokedCommunityRole {
+        community_id: String,
+        role_id: String,
+        user: String,
+    },
+    CreatedCommunityChannel {
+        community_id: String,
+        channel: CommunityChannel,
+    },
+    DeletedCommunityChannel {
+        community_id: String,
+        channel_id: String,
+    },
+    EditedCommunityName {
+        community_id: String,
+        name: String,
+    },
+    EditedCommunityDescription {
+        community_id: String,
+        description: Option<String>,
+    },
+    EditedCommunityIcon {
+        community_id: String,
+    },
+    EditedCommunityBanner {
+        community_id: String,
+    },
+    GrantedCommunityPermission {
+        community_id: String,
+        permission: CommunityPermission,
+        role_id: String,
+    },
+    RevokedCommunityPermission {
+        community_id: String,
+        permission: CommunityPermission,
+        role_id: String,
+    },
+    GrantedCommunityPermissionForAll {
+        community_id: String,
+        permission: CommunityPermission,
+    },
+    RevokedCommunityPermissionForAll {
+        community_id: String,
+        permission: CommunityPermission,
+    },
+    RemovedCommunityMember {
+        community_id: String,
+        member: String,
+    },
+    EditedCommunityChannelName {
+        community_id: String,
+        channel_id: String,
+        name: String,
+    },
+    EditedCommunityChannelDescription {
+        community_id: String,
+        channel_id: String,
+        description: Option<String>,
+    },
+    GrantedCommunityChannelPermission {
+        community_id: String,
+        channel_id: String,
+        permission: CommunityChannelPermission,
+        role_id: String,
+    },
+    RevokedCommunityChannelPermission {
+        community_id: String,
+        channel_id: String,
+        permission: CommunityChannelPermission,
+        role_id: String,
+    },
+    GrantedCommunityChannelPermissionForAll {
+        community_id: String,
+        channel_id: String,
+        permission: CommunityChannelPermission,
+    },
+    RevokedCommunityChannelPermissionForAll {
+        community_id: String,
+        channel_id: String,
+        permission: CommunityChannelPermission,
+    },
+    CommunityMessageSent {
+        community_id: String,
+        channel_id: String,
+        message_id: String,
+    },
+    CommunityMessageReceived {
+        community_id: String,
+        channel_id: String,
+        message_id: String,
+    },
+    CommunityMessageEdited {
+        community_id: String,
+        channel_id: String,
+        message_id: String,
+    },
+    CommunityMessageDeleted {
+        community_id: String,
+        channel_id: String,
+        message_id: String,
+    },
+    CommunityMessagePinned {
+        community_id: String,
+        channel_id: String,
+        message_id: String,
+    },
+    CommunityMessageUnpinned {
+        community_id: String,
+        channel_id: String,
+        message_id: String,
+    },
+    CommunityMessageReactionAdded {
+        community_id: String,
+        channel_id: String,
+        message_id: String,
+        did_key: String,
+        reaction: String,
+    },
+    CommunityMessageReactionRemoved {
+        community_id: String,
+        channel_id: String,
+        message_id: String,
+        did_key: String,
+        reaction: String,
+    },
+}
+
+fn map_permission(entries: Vec<(DID, warp::raygun::GroupPermission)>) -> Vec<GroupPermissionEntry> {
+    entries
+        .into_iter()
+        .map(|(user, permission)| GroupPermissionEntry {
+            user: user.to_string(),
+            permission: permission.into(),
+        })
+        .collect()
+}
+
+#[derive(Serialize, Deserialize)]
+#[wasm_bindgen]
+pub struct GroupPermissionEntry {
+    #[wasm_bindgen(readonly, getter_with_clone)]
+    pub user: String,
+    #[wasm_bindgen(readonly, getter_with_clone)]
+    pub permission: GroupPermission,
+}
+
 #[derive(Serialize, Deserialize)]
 #[wasm_bindgen]
 pub struct Page {
@@ -1801,98 +2102,53 @@ impl From<raygun::AttachmentKind> for AttachmentKind {
 }
 
 #[wasm_bindgen]
+#[derive(FromTo)]
+#[from_to(warp::raygun::EmbedState)]
 pub enum EmbedState {
     Enabled,
     Disable,
 }
 
-impl From<EmbedState> for warp::raygun::EmbedState {
-    fn from(value: EmbedState) -> Self {
-        match value {
-            EmbedState::Enabled => raygun::EmbedState::Enabled,
-            EmbedState::Disable => raygun::EmbedState::Disable,
-        }
-    }
-}
-
 #[wasm_bindgen]
+#[derive(FromTo)]
+#[from_to(warp::raygun::PinState)]
 pub enum PinState {
     Pin,
     Unpin,
 }
 
-impl From<PinState> for warp::raygun::PinState {
-    fn from(value: PinState) -> Self {
-        match value {
-            PinState::Pin => raygun::PinState::Pin,
-            PinState::Unpin => raygun::PinState::Unpin,
-        }
-    }
-}
-
 #[wasm_bindgen]
+#[derive(FromTo)]
+#[from_to(warp::raygun::ReactionState)]
 pub enum ReactionState {
     Add,
     Remove,
 }
 
-impl From<ReactionState> for warp::raygun::ReactionState {
-    fn from(value: ReactionState) -> Self {
-        match value {
-            ReactionState::Add => raygun::ReactionState::Add,
-            ReactionState::Remove => raygun::ReactionState::Remove,
-        }
-    }
-}
-
 #[wasm_bindgen]
+#[derive(FromTo)]
+#[from_to(warp::raygun::MessageStatus)]
 pub enum MessageStatus {
     NotSent,
     Sent,
     Delivered,
 }
 
-impl From<warp::raygun::MessageStatus> for MessageStatus {
-    fn from(value: warp::raygun::MessageStatus) -> Self {
-        match value {
-            warp::raygun::MessageStatus::NotSent => MessageStatus::NotSent,
-            warp::raygun::MessageStatus::Sent => MessageStatus::Sent,
-            warp::raygun::MessageStatus::Delivered => MessageStatus::Delivered,
-        }
-    }
-}
-
 #[wasm_bindgen]
+#[derive(FromTo)]
+#[from_to(warp::raygun::MessageType)]
 pub enum MessageType {
     Message,
     Attachment,
     Event,
 }
 
-impl From<warp::raygun::MessageType> for MessageType {
-    fn from(value: warp::raygun::MessageType) -> Self {
-        match value {
-            warp::raygun::MessageType::Message => MessageType::Message,
-            warp::raygun::MessageType::Attachment => MessageType::Attachment,
-            warp::raygun::MessageType::Event => MessageType::Event,
-        }
-    }
-}
-
 #[wasm_bindgen]
-#[derive(Copy, Clone)]
+#[derive(FromTo)]
+#[from_to(warp::raygun::ConversationType)]
 pub enum ConversationType {
     Direct,
     Group,
-}
-
-impl From<warp::raygun::ConversationType> for ConversationType {
-    fn from(value: warp::raygun::ConversationType) -> Self {
-        match value {
-            raygun::ConversationType::Direct => ConversationType::Direct,
-            raygun::ConversationType::Group => ConversationType::Group,
-        }
-    }
 }
 
 #[wasm_bindgen]
@@ -1902,39 +2158,14 @@ extern "C" {
     pub type GroupPermissionList;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, FromTo)]
+#[from_to(warp::raygun::GroupPermission)]
 #[wasm_bindgen]
 pub enum GroupPermission {
     AddParticipants,
     RemoveParticipants,
     EditGroupInfo,
     EditGroupImages,
-}
-
-impl From<GroupPermission> for warp::raygun::GroupPermission {
-    fn from(value: GroupPermission) -> Self {
-        match value {
-            GroupPermission::AddParticipants => warp::raygun::GroupPermission::AddParticipants,
-            GroupPermission::RemoveParticipants => {
-                warp::raygun::GroupPermission::RemoveParticipants
-            }
-            GroupPermission::EditGroupInfo => warp::raygun::GroupPermission::EditGroupInfo,
-            GroupPermission::EditGroupImages => warp::raygun::GroupPermission::EditGroupImages,
-        }
-    }
-}
-
-impl From<warp::raygun::GroupPermission> for GroupPermission {
-    fn from(value: warp::raygun::GroupPermission) -> Self {
-        match value {
-            warp::raygun::GroupPermission::AddParticipants => GroupPermission::AddParticipants,
-            warp::raygun::GroupPermission::RemoveParticipants => {
-                GroupPermission::RemoveParticipants
-            }
-            warp::raygun::GroupPermission::EditGroupInfo => GroupPermission::EditGroupInfo,
-            warp::raygun::GroupPermission::EditGroupImages => GroupPermission::EditGroupImages,
-        }
-    }
 }
 
 #[wasm_bindgen]
@@ -1995,24 +2226,19 @@ impl ConversationImage {
     }
 
     pub fn image_type(&self) -> FileType {
-        self.0.image_type().into()
+        self.0.image_type().clone().into()
     }
 }
 
+#[derive(FromTo, Serialize, Deserialize)]
+#[from_to(warp::raygun::MessageEvent)]
 #[wasm_bindgen]
 pub enum MessageEvent {
     Typing,
 }
 
-impl From<MessageEvent> for warp::raygun::MessageEvent {
-    fn from(value: MessageEvent) -> Self {
-        match value {
-            MessageEvent::Typing => raygun::MessageEvent::Typing,
-        }
-    }
-}
-
-#[derive(Tsify, Deserialize, Serialize)]
+#[derive(Tsify, Deserialize, Serialize, FromTo)]
+#[from_to(raygun::MessagesType)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum MessagesType {
     /// Stream type
@@ -2026,22 +2252,6 @@ pub enum MessagesType {
         /// Amount of messages per page
         amount_per_page: Option<usize>,
     },
-}
-
-impl From<MessagesType> for raygun::MessagesType {
-    fn from(value: MessagesType) -> Self {
-        match value {
-            MessagesType::Stream => raygun::MessagesType::Stream,
-            MessagesType::List => raygun::MessagesType::List,
-            MessagesType::Pages {
-                page,
-                amount_per_page,
-            } => raygun::MessagesType::Pages {
-                page,
-                amount_per_page,
-            },
-        }
-    }
 }
 
 #[wasm_bindgen]
@@ -2108,7 +2318,7 @@ pub struct CommunityInvitation {
     pub invite: CommunityInvite,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 #[wasm_bindgen]
 pub struct CommunityInvite {
     #[wasm_bindgen(getter_with_clone)]
@@ -2116,9 +2326,39 @@ pub struct CommunityInvite {
     #[wasm_bindgen(getter_with_clone)]
     pub target_user: Option<String>,
     #[wasm_bindgen(getter_with_clone)]
+    #[serde(with = "serde_wasm_bindgen::preserve")]
     pub created: js_sys::Date,
     #[wasm_bindgen(getter_with_clone)]
+    #[serde(
+        deserialize_with = "deserialize_optional",
+        serialize_with = "serialize_optional"
+    )]
     pub expiry: Option<js_sys::Date>,
+}
+
+fn deserialize_optional<'de, D: serde::Deserializer<'de>, T: wasm_bindgen::JsCast>(
+    de: D,
+) -> Result<Option<T>, D::Error> {
+    let value: JsValue = serde_wasm_bindgen::preserve::deserialize(de)?;
+    Ok(if value.is_undefined() {
+        None
+    } else {
+        Some(
+            value
+                .dyn_into()
+                .map_err(|_| serde::de::Error::custom("Could not convert optional value"))?,
+        )
+    })
+}
+
+fn serialize_optional<S: serde::Serializer, T: JsCast>(
+    val: &Option<T>,
+    ser: S,
+) -> Result<S::Ok, S::Error> {
+    match val {
+        Some(opt) => serde_wasm_bindgen::preserve::serialize(opt, ser),
+        None => ser.serialize_none(),
+    }
 }
 
 impl From<raygun::community::CommunityInvite> for CommunityInvite {
@@ -2172,6 +2412,7 @@ extern "C" {
 }
 
 #[wasm_bindgen]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct CommunityChannel {
     #[wasm_bindgen(readonly, getter_with_clone)]
     pub id: String,
@@ -2180,8 +2421,10 @@ pub struct CommunityChannel {
     #[wasm_bindgen(readonly, getter_with_clone)]
     pub description: Option<String>,
     #[wasm_bindgen(readonly, getter_with_clone)]
+    #[serde(with = "serde_wasm_bindgen::preserve")]
     pub created: js_sys::Date,
     #[wasm_bindgen(readonly, getter_with_clone)]
+    #[serde(with = "serde_wasm_bindgen::preserve")]
     pub modified: js_sys::Date,
     #[wasm_bindgen(readonly, getter_with_clone)]
     pub channel_type: CommunityChannelType,
@@ -2190,7 +2433,7 @@ pub struct CommunityChannel {
 
 impl From<raygun::community::CommunityChannel> for CommunityChannel {
     fn from(value: raygun::community::CommunityChannel) -> Self {
-        CommunityChannel {
+        Self {
             id: value.id().into(),
             name: value.name().into(),
             description: value.description().map(|d| d.into()),
@@ -2209,35 +2452,16 @@ impl CommunityChannel {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Serialize, Deserialize, FromTo)]
+#[from_to(raygun::community::CommunityChannelType)]
 #[wasm_bindgen]
 pub enum CommunityChannelType {
     Standard,
     VoiceEnabled,
 }
 
-impl From<raygun::community::CommunityChannelType> for CommunityChannelType {
-    fn from(value: raygun::community::CommunityChannelType) -> Self {
-        match value {
-            raygun::community::CommunityChannelType::Standard => CommunityChannelType::Standard,
-            raygun::community::CommunityChannelType::VoiceEnabled => {
-                CommunityChannelType::VoiceEnabled
-            }
-        }
-    }
-}
-
-impl From<CommunityChannelType> for raygun::community::CommunityChannelType {
-    fn from(value: CommunityChannelType) -> Self {
-        match value {
-            CommunityChannelType::Standard => raygun::community::CommunityChannelType::Standard,
-            CommunityChannelType::VoiceEnabled => {
-                raygun::community::CommunityChannelType::VoiceEnabled
-            }
-        }
-    }
-}
-
+#[derive(FromTo, Serialize, Deserialize)]
+#[from_to(raygun::community::CommunityPermission)]
 #[wasm_bindgen]
 pub enum CommunityPermission {
     EditName,
@@ -2269,72 +2493,11 @@ pub enum CommunityPermission {
     PinMessages,
 }
 
-impl From<CommunityPermission> for raygun::community::CommunityPermission {
-    fn from(value: CommunityPermission) -> Self {
-        match value {
-            CommunityPermission::EditName => raygun::community::CommunityPermission::EditName,
-            CommunityPermission::EditDescription => {
-                raygun::community::CommunityPermission::EditDescription
-            }
-            CommunityPermission::EditIcon => raygun::community::CommunityPermission::EditIcon,
-            CommunityPermission::EditBanner => raygun::community::CommunityPermission::EditBanner,
-            CommunityPermission::CreateRoles => raygun::community::CommunityPermission::CreateRoles,
-            CommunityPermission::EditRoles => raygun::community::CommunityPermission::EditRoles,
-            CommunityPermission::DeleteRoles => raygun::community::CommunityPermission::DeleteRoles,
-            CommunityPermission::GrantRoles => raygun::community::CommunityPermission::GrantRoles,
-            CommunityPermission::RevokeRoles => raygun::community::CommunityPermission::RevokeRoles,
-            CommunityPermission::GrantPermissions => {
-                raygun::community::CommunityPermission::GrantPermissions
-            }
-            CommunityPermission::RevokePermissions => {
-                raygun::community::CommunityPermission::RevokePermissions
-            }
-            CommunityPermission::CreateInvites => {
-                raygun::community::CommunityPermission::CreateInvites
-            }
-            CommunityPermission::EditInvites => raygun::community::CommunityPermission::EditInvites,
-            CommunityPermission::DeleteInvites => {
-                raygun::community::CommunityPermission::DeleteInvites
-            }
-            CommunityPermission::CreateChannels => {
-                raygun::community::CommunityPermission::CreateChannels
-            }
-            CommunityPermission::EditChannels => {
-                raygun::community::CommunityPermission::EditChannels
-            }
-            CommunityPermission::DeleteChannels => {
-                raygun::community::CommunityPermission::DeleteChannels
-            }
-            CommunityPermission::RemoveMembers => {
-                raygun::community::CommunityPermission::RemoveMembers
-            }
-            CommunityPermission::DeleteMessages => {
-                raygun::community::CommunityPermission::DeleteMessages
-            }
-            CommunityPermission::PinMessages => raygun::community::CommunityPermission::PinMessages,
-        }
-    }
-}
-
+#[derive(FromTo, Serialize, Deserialize)]
+#[from_to(raygun::community::CommunityChannelPermission)]
 #[wasm_bindgen]
 pub enum CommunityChannelPermission {
     ViewChannel,
     SendMessages,
     SendAttachments,
-}
-
-impl From<CommunityChannelPermission> for raygun::community::CommunityChannelPermission {
-    fn from(value: CommunityChannelPermission) -> Self {
-        match value {
-            CommunityChannelPermission::ViewChannel => {
-                raygun::community::CommunityChannelPermission::ViewChannel
-            }
-            CommunityChannelPermission::SendMessages => {
-                raygun::community::CommunityChannelPermission::SendMessages
-            }
-            CommunityChannelPermission::SendAttachments => {
-                raygun::community::CommunityChannelPermission::SendAttachments
-            }
-        }
-    }
 }

--- a/src/warp/raygun.rs
+++ b/src/warp/raygun.rs
@@ -565,9 +565,9 @@ impl RayGunBox {
             .await
             .map_err(|e| e.into())
             .map(|ok| {
-                AsyncIterator::new(Box::pin(
-                    ok.map(|s| serde_wasm_bindgen::to_value(&Into::<MessageEventKind>::into(s)).unwrap()),
-                ))
+                AsyncIterator::new(Box::pin(ok.map(|s| {
+                    serde_wasm_bindgen::to_value(&Into::<MessageEventKind>::into(s)).unwrap()
+                })))
             })
     }
 
@@ -1504,6 +1504,7 @@ impl Messages {
 
 #[derive(Tsify, Serialize, Deserialize, FromTo)]
 #[from_to(warp::raygun::RayGunEventKind, only = "from")]
+#[serde(tag = "kind", content = "values", rename_all = "snake_case")]
 pub enum RayGunEventKind {
     ConversationCreated {
         conversation_id: String,
@@ -1531,6 +1532,7 @@ pub enum RayGunEventKind {
 
 #[derive(Tsify, Serialize, Deserialize, FromTo)]
 #[from_to(warp::raygun::MessageEventKind, only = "from")]
+#[serde(tag = "kind", content = "values", rename_all = "snake_case")]
 pub enum MessageEventKind {
     MessageSent {
         conversation_id: String,


### PR DESCRIPTION
Adds a macro that auto converts between wasm <-> warp structs and enums.
Also exposes some enums that were previously not (e.g. raygun events) and improving typings. Some wrapper structs that contained setters were not modified.
