### PR TITLE
feat: Use ReadableStream instead of a stream of bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
  "synstructure 0.13.1",
 ]
 
@@ -171,7 +171,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -250,7 +250,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -261,7 +261,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -559,9 +559,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
 dependencies = [
  "jobserver",
  "libc",
@@ -851,9 +851,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -870,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -981,7 +981,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1064,7 +1064,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1085,7 +1085,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
  "unicode-xid",
 ]
 
@@ -1148,7 +1148,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1296,7 +1296,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1429,9 +1429,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "form_urlencoded"
@@ -1554,7 +1554,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2170,9 +2170,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2330,7 +2330,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2508,7 +2508,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2615,9 +2615,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3149,7 +3149,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3495,9 +3495,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3626,7 +3626,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
  "synstructure 0.13.1",
 ]
 
@@ -3782,7 +3782,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3826,9 +3826,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -3984,7 +3984,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4027,9 +4027,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "png"
-version = "0.17.15"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67582bd5b65bdff614270e2ea89a1cf15bef71245cc1e5f7ea126977144211d"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
@@ -4177,7 +4177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4200,7 +4200,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4260,7 +4260,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "rustls",
  "socket2",
- "thiserror 2.0.6",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
 ]
@@ -4279,7 +4279,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.6",
+ "thiserror 2.0.9",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4287,9 +4287,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4458,9 +4458,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
  "pem",
  "ring 0.17.8",
@@ -4472,9 +4472,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4628,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "rust-ipfs"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d965f926191577a1eefe10ecdf38cb749faa92e2a266ab917283007fc1b50902"
+checksum = "df0c1d5ed637921744846e8e74af49964b604bba549068df19ecb77fec2687a9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4670,7 +4670,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rcgen 0.13.1",
+ "rcgen 0.13.2",
  "rlimit",
  "rust-ipns",
  "rust-unixfs",
@@ -4683,7 +4683,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "simple_x509",
- "thiserror 2.0.6",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4782,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
@@ -4796,9 +4796,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
  "web-time",
 ]
@@ -4877,9 +4877,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "send_wrapper"
@@ -4898,9 +4898,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
@@ -4959,13 +4959,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4976,7 +4976,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5004,9 +5004,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "itoa",
  "memchr",
@@ -5315,9 +5315,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5344,7 +5344,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5432,11 +5432,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.6"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -5447,18 +5447,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5566,9 +5566,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5605,7 +5605,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5705,7 +5705,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5798,7 +5798,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6067,7 +6067,7 @@ dependencies = [
  "js-sys",
  "send_wrapper 0.6.0",
  "serde",
- "serde-wasm-bindgen 0.4.5",
+ "serde-wasm-bindgen 0.6.5",
  "tiny_file_server",
  "tracing-subscriber",
  "tracing-wasm",
@@ -6114,7 +6114,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
  "wasm-bindgen-shared",
 ]
 
@@ -6149,7 +6149,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6584,7 +6584,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
  "synstructure 0.13.1",
 ]
 
@@ -6606,7 +6606,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6626,7 +6626,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
  "synstructure 0.13.1",
 ]
 
@@ -6647,7 +6647,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6669,7 +6669,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6689,9 +6689,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16099418600b4d8f028622f73ff6e3deaabdff330fb9a2a131dea781ee8b0768"
+checksum = "99a5bab8d7dedf81405c4bb1f2b83ea057643d9cb28778cea9eecddeedd2e028"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ warp-ipfs = { git = "https://github.com/Satellite-im/Warp.git", rev = "fdb96da58
 warp = { git = "https://github.com/Satellite-im/Warp.git", rev = "fdb96da58174b41548992b3dcaba40a01b10ecf9"}
 
 # wasm
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-wasm = "0.2.0"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-wasm = "0.2.1"
 console_error_panic_hook = "0.1.7"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
-serde-wasm-bindgen = "0.4"
-wasm-streams = "0.4"
+wasm-bindgen = "0.2.99"
+wasm-bindgen-futures = "0.4.49"
+serde-wasm-bindgen = "0.6.5"
+wasm-streams = "0.4.2"
 send_wrapper = "0.6.0"
-web-sys = "0.3"
+web-sys = "0.3.76"
 js-sys = "0.3"
 tsify-next = "0.5.4"
 

--- a/examples/from-js/ipfs-constellation.html
+++ b/examples/from-js/ipfs-constellation.html
@@ -49,18 +49,21 @@
         }
       }
 
-      let get_stream_async_iterator = await ipfs.constellation.get_stream("circle.png")
-      let get_stream = { [Symbol.asyncIterator]() { return get_stream_async_iterator } }
-      let circle_data = []; 
-      for await (const value of get_stream) {
-        console.log(value)
-        if (value.Ok != null) {
-          circle_data = value.Ok
-          break
-        }
-      }
+      let get_stream = await ipfs.constellation.get_stream("circle.png")
+
+
+
       append_p("stream result:")
-      append_img(data_type, circle_data)
+      let res = new Response(get_stream);
+      let blob = await res.blob();
+      let uri = URL.createObjectURL(blob);
+
+      console.log(uri);
+      // display
+      append_img_uri(uri);
+      
+      // dowbloadable link
+      append_a(uri);
 
     });
 
@@ -75,6 +78,20 @@
       let p = document.createElement("p")
       p.appendChild(document.createTextNode(text))
       document.body.appendChild(p)      
+    }
+
+    function append_a(text) {
+      let p = document.createElement("a")
+      p.href = text;
+      p.appendChild(document.createTextNode("click me"));
+      p.download = "test.png";
+      document.body.appendChild(p)
+    }
+
+    function append_img_uri(uri) {
+      let img = document.createElement("img")
+      img.src =  uri
+      document.body.appendChild(img)
     }
 
     function append_img(data_type, data) {

--- a/examples/from-js/ipfs-constellation.html
+++ b/examples/from-js/ipfs-constellation.html
@@ -60,7 +60,7 @@
       // display
       append_img_uri(uri);
 
-      // dowbloadable link
+      // downloadable link
       append_a(uri);
 
     });

--- a/examples/from-js/ipfs-constellation.html
+++ b/examples/from-js/ipfs-constellation.html
@@ -61,7 +61,7 @@
       console.log(uri);
       // display
       append_img_uri(uri);
-      
+
       // dowbloadable link
       append_a(uri);
 

--- a/examples/from-js/ipfs-constellation.html
+++ b/examples/from-js/ipfs-constellation.html
@@ -51,8 +51,6 @@
 
       let get_stream = await ipfs.constellation.get_stream("circle.png")
 
-
-
       append_p("stream result:")
       let res = new Response(get_stream);
       let blob = await res.blob();

--- a/src/warp/constellation.rs
+++ b/src/warp/constellation.rs
@@ -1,4 +1,4 @@
-use crate::warp::stream::{AsyncIterator, InnerStream};
+use crate::warp::stream::{stream_to_readablestream, AsyncIterator, InnerStream};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use tsify_next::Tsify;
@@ -112,16 +112,16 @@ impl ConstellationBox {
 
     /// Returns a file stream
     /// Each stream element is a byte array chunk of the file
-    pub async fn get_stream(&self, name: &str) -> Result<AsyncIterator, JsError> {
+    pub async fn get_stream(&self, name: &str) -> Result<web_sys::ReadableStream, JsError> {
         self.inner
             .get_stream(name)
             .await
             .map_err(|e| e.into())
             .map(|s| {
-                AsyncIterator::new(Box::pin(s.map(|t| {
-                    serde_wasm_bindgen::to_value(&t.map_err(|e| String::from(e.to_string())))
-                        .unwrap()
-                })))
+                let st = s.map(|val| {
+                    val.map_err(|e| e.to_string()).and_then(|v| serde_wasm_bindgen::to_value(&v).map_err(|e| e.to_string())).unwrap()
+                }).boxed();
+                stream_to_readablestream(st)
             })
     }
 

--- a/src/warp/raygun.rs
+++ b/src/warp/raygun.rs
@@ -1,4 +1,4 @@
-use crate::warp::stream::{AsyncIterator, InnerStream};
+use crate::warp::stream::{stream_to_readablestream, AsyncIterator, InnerStream};
 use futures::StreamExt;
 use indexmap::IndexSet;
 use js_sys::{Array, Promise};
@@ -494,7 +494,7 @@ impl RayGunBox {
         conversation_id: String,
         message_id: String,
         file: String,
-    ) -> Result<AsyncIterator, JsError> {
+    ) -> Result<web_sys::ReadableStream, JsError> {
         self.inner
             .download_stream(
                 Uuid::from_str(&conversation_id).unwrap(),
@@ -504,13 +504,10 @@ impl RayGunBox {
             .await
             .map_err(|e| e.into())
             .map(|ok| {
-                AsyncIterator::new(Box::pin(ok.map(|s| match s {
-                    Ok(v) => serde_wasm_bindgen::to_value(&v).unwrap(),
-                    Err(e) => {
-                        let err: JsError = e.into();
-                        err.into()
-                    }
-                })))
+                let st = ok.map(|val| {
+                    val.map_err(|e| e.to_string()).and_then(|v| serde_wasm_bindgen::to_value(&v).map_err(|e| e.to_string())).unwrap()
+                }).boxed();
+                stream_to_readablestream(st)
             })
     }
 }

--- a/src/warp/stream.rs
+++ b/src/warp/stream.rs
@@ -90,7 +90,6 @@ pub fn stream_to_readablestream(stream: BoxStream<'static, JsValue>) -> web_sys:
     // We encase the stream in mutex as a temporary workaround, but since the scope would have sole access that is not shared, we do not need to worry about deadlocks or borrowed access
     let stream = Arc::new(Mutex::new(stream));
     let closure = Closure::wrap(Box::new({
-        let stream = stream.clone();
         move |controller: ReadableStreamDefaultController| {
             let stream = stream.clone();
             wasm_bindgen_futures::spawn_local(async move {

--- a/src/warp/stream.rs
+++ b/src/warp/stream.rs
@@ -1,8 +1,10 @@
 use futures::{stream::BoxStream, Stream, StreamExt};
-use js_sys::Promise;
+use js_sys::{Object, Promise};
 use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use wasm_bindgen::prelude::*;
+use web_sys::{ReadableStream, ReadableStreamDefaultController};
 
 /// Wraps BoxStream<'static, TesseractEvent> into a js compatible struct
 /// Currently there is no generic way for this so on JS-side this returns any
@@ -81,4 +83,33 @@ impl Stream for InnerStream {
             }
         }
     }
+}
+
+/// converts a Stream to a ReadableStream
+pub fn stream_to_readablestream(stream: BoxStream<'static, JsValue>) -> web_sys::ReadableStream {
+    // We encase the stream in mutex as a temporary workaround, but since the scope would have sole access that is not shared, we do not need to worry about deadlocks or borrowed access
+    let stream = Arc::new(Mutex::new(stream));
+    let closure = Closure::wrap(Box::new({
+        let stream = stream.clone();
+        move |controller: ReadableStreamDefaultController| {
+            let stream = stream.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let stream = &mut *stream.lock().unwrap();
+                while let Some(item) = stream.next().await {
+                    controller.enqueue_with_chunk(&item).unwrap();
+                }
+                controller.close().unwrap();
+            });
+        }
+    }) as Box<dyn FnMut(_)>);
+
+    let object = Object::new();
+
+    js_sys::Reflect::set(&object, &JsValue::from("start"), &closure.as_ref().unchecked_ref()).unwrap();
+
+    closure.forget();
+
+    let readable_st = ReadableStream::new_with_underlying_source(&object).unwrap();
+
+    readable_st
 }


### PR DESCRIPTION
Previously, we would use an AsyncIterator for handling rust streams, and in some situations they do work well but it can be a problem when it comes to handling streams for files as these would be chunks of data that is streamed. While an AsyncIterator could handle it, it may not be idiomatic to work with other functions without redundant workarounds. Additionally, in some cases, would require to buffer the data, which is not ideal for large sums of data.

This PR, while more of a PoC, would begin the process of using `ReadableStream` in place of `AsyncIterator`, which should work best for different situations such as creating a blob to download files without the need to buffer them. In other situations, could probably be used in place of `AsyncIterator` for events, however that would need discussions to determine if that might be suitable. 