### PR TITLE
fix: fix typo for fn

### DIFF
--- a/src/warp/raygun.rs
+++ b/src/warp/raygun.rs
@@ -1244,7 +1244,7 @@ impl RayGunBox {
             .await
             .map_err(|e| e.into())
     }
-    pub async fn send_community_channel_messsage_event(
+    pub async fn send_community_channel_message_event(
         &mut self,
         community_id: String,
         channel_id: String,
@@ -1259,7 +1259,7 @@ impl RayGunBox {
             .await
             .map_err(|e| e.into())
     }
-    pub async fn cancel_community_channel_messsage_event(
+    pub async fn cancel_community_channel_message_event(
         &mut self,
         community_id: String,
         channel_id: String,


### PR DESCRIPTION
fix typo in community api where message was written with 3 s